### PR TITLE
Fix calculation of payload-length in write-frame

### DIFF
--- a/hunchensocket.lisp
+++ b/hunchensocket.lisp
@@ -283,7 +283,7 @@ format control and arguments."
   (let* ((first-byte     #x00)
          (second-byte    #x00)
          (len            (if data (length data) 0))
-         (payload-length (cond ((< len 125)         len)
+         (payload-length (cond ((<= len 125)        len)
                                ((< len (expt 2 16)) 126)
                                (t                   127)))
          (mask-p         nil))


### PR DESCRIPTION
I fixed bug that write-frame function makes illegal payload-length when given 125 bytes data.