### PR TITLE
Add missing SEND-BINARY-MESSAGE function.

### DIFF
--- a/hunchensocket.lisp
+++ b/hunchensocket.lisp
@@ -99,6 +99,11 @@
               (flexi-streams:string-to-octets message
                                               :external-format :utf-8)))
 
+(defun send-binary-message (client message)
+  "MESSAGE is an array of octets"
+  (send-frame client +binary-frame+
+              message))
+
 (defun close-connection (client &key data status reason)
   (send-frame client
               +connection-close+


### PR DESCRIPTION
You had exported the SEND-BINARY-MESSAGE symbol along with SEND-TEXT-MESSAGE, but the (trivial) implementation was missing.

You might also consider using CHECK-TYPE for those two functions, though I add that in this branch.